### PR TITLE
Fix file header spelling errors

### DIFF
--- a/behavior_pack/functions/bcc.cook/hub/display_actionbar.mcfunction
+++ b/behavior_pack/functions/bcc.cook/hub/display_actionbar.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/hub/on_join.mcfunction
+++ b/behavior_pack/functions/bcc.cook/hub/on_join.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/hub/replay_music.mcfunction
+++ b/behavior_pack/functions/bcc.cook/hub/replay_music.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/main.mcfunction
+++ b/behavior_pack/functions/bcc.cook/main.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/end_game/0.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/end_game/0.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/end_game/1.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/end_game/1.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/lobby/display_actionbar.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/lobby/display_actionbar.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/lobby/join.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/lobby/join.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/lobby/leave.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/lobby/leave.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/lobby/start_game.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/lobby/start_game.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/on.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/on.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/staging_initiation/0.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/staging_initiation/0.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/map_1/staging_initiation/1.mcfunction
+++ b/behavior_pack/functions/bcc.cook/map_1/staging_initiation/1.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/scoreboard/objectives/add_all.mcfunction
+++ b/behavior_pack/functions/bcc.cook/scoreboard/objectives/add_all.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/scoreboard/objectives/refresh_list.mcfunction
+++ b/behavior_pack/functions/bcc.cook/scoreboard/objectives/refresh_list.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/behavior_pack/functions/bcc.cook/scoreboard/objectives/reset_all.mcfunction
+++ b/behavior_pack/functions/bcc.cook/scoreboard/objectives/reset_all.mcfunction
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) @zheaEvyline & Contributors
-# Contributers:
+# Contributors:
 # See LICENSE.md file in the root folder, licenses/MIT.md, or https://opensource.org/license/mit
 
 

--- a/resource_pack/animations/bcc.cook/celery.chop.animation.json
+++ b/resource_pack/animations/bcc.cook/celery.chop.animation.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @r_kidds & Contributors
-// Contributers: @r_kidds
+// Contributors: @r_kidds
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/animations/bcc.cook/cheese.chop.animation.json
+++ b/resource_pack/animations/bcc.cook/cheese.chop.animation.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @r_kidds & Contributors
-// Contributers: @r_kidds
+// Contributors: @r_kidds
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/animations/bcc.cook/tomato.chop.animation.json
+++ b/resource_pack/animations/bcc.cook/tomato.chop.animation.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @r_kidds & Contributors
-// Contributers: @r_kidds
+// Contributors: @r_kidds
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/Microwave.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/Microwave.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/bowls/bowl.empty.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/bowls/bowl.empty.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @brodblox09 & Contributors
-// Contributers: @brodblox09
+// Contributors: @brodblox09
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 /**

--- a/resource_pack/models/blocks/bcc.cook/cabinet.oak_wood.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/cabinet.oak_wood.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/chair.oak_wood.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/chair.oak_wood.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/chopping_board.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/chopping_board.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/cooked_meatball.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/cooked_meatball.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/counter.brick.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/counter.brick.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/counter.oak_wood.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/counter.oak_wood.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/cutting_board.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/cutting_board.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce_patty.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce_patty.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce_patty_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce_patty_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_lettuce_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_patty.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_patty.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_patty_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_cheese_patty_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce_patty.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce_patty.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce_patty_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce_patty_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_lettuce_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_patty.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_patty.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_patty_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_patty_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dishes/starting_restaurant/burgers/buns_tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/dough.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/dough.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/fire_extinguisher.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/fire_extinguisher.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/fridge.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/fridge.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/frying_pan.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/frying_pan.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/ice_box.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/ice_box.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/ingredients/burger_buns.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/ingredients/burger_buns.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/ingredients/celery.json
+++ b/resource_pack/models/blocks/bcc.cook/ingredients/celery.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @r_kidds & Contributors
-// Contributers: @r_kidds
+// Contributors: @r_kidds
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/ingredients/cheese.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/ingredients/cheese.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @r_kidds & Contributors
-// Contributers: @r_kidds
+// Contributors: @r_kidds
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/ingredients/chicken.raw.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/ingredients/chicken.raw.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/ingredients/tomato.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/ingredients/tomato.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @r_kidds & Contributors
-// Contributers: @r_kidds
+// Contributors: @r_kidds
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/jar_1.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/jar_1.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/jar_2.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/jar_2.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/milk.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/milk.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/oven.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/oven.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/pepper.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/pepper.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/pizza_board.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/pizza_board.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/pizza_furnace.bottom.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/pizza_furnace.bottom.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/pizza_furnace.top.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/pizza_furnace.top.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/plate.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/plate.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/pot.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/pot.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/raw_meatball.json
+++ b/resource_pack/models/blocks/bcc.cook/raw_meatball.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/salt.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/salt.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/serving_station.brick.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/serving_station.brick.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/shelf.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/shelf.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/sink.brick.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/sink.brick.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @faramir1616 & Contributors
-// Contributers: @faramir1616
+// Contributors: @faramir1616
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/soy_sauce.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/soy_sauce.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/storage_crates/storage_crate.closed.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/storage_crates/storage_crate.closed.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/storage_crates/storage_crate.item.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/storage_crates/storage_crate.item.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty @brodblox09
+// Contributors: @itzbeasty @brodblox09
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/storage_crates/storage_crate.open.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/storage_crates/storage_crate.open.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty @brodblox09
+// Contributors: @itzbeasty @brodblox09
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 /**

--- a/resource_pack/models/blocks/bcc.cook/stoves/stove.dark_gray.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/stoves/stove.dark_gray.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @brodblox09 & Contributors
-// Contributers: @brodblox09
+// Contributors: @brodblox09
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 /**

--- a/resource_pack/models/blocks/bcc.cook/stoves/stove.metal.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/stoves/stove.metal.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 {
 	"format_version": "1.12.0",

--- a/resource_pack/models/blocks/bcc.cook/table.oak_wood_1.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/table.oak_wood_1.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/table.oak_wood_2.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/table.oak_wood_2.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @hi_rynnn & Contributors
-// Contributers: @hi_rynnn
+// Contributors: @hi_rynnn
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/tapioca_pearls.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/tapioca_pearls.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/trash_bin.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/trash_bin.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @itzbeasty & Contributors
-// Contributers: @itzbeasty
+// Contributors: @itzbeasty
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 

--- a/resource_pack/models/blocks/bcc.cook/vinegar.geo.json
+++ b/resource_pack/models/blocks/bcc.cook/vinegar.geo.json
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-BCC-PL-v1.0
 // Copyright (c) @bellarmina & Contributors
-// Contributers: @bellarmina
+// Contributors: @bellarmina
 // See LICENSE.md file in the root folder, licenses/BCC-PL-v1.0.md, or https://bedrockcommands.org/legal/bcc-pl-v1.0
 
 


### PR DESCRIPTION
"Contributers" is now properly spelled as "Contributors"