### PR TITLE
Fix oak wood counter display bug

### DIFF
--- a/behavior_pack/blocks/bcc.cook/counter.oak_wood.json
+++ b/behavior_pack/blocks/bcc.cook/counter.oak_wood.json
@@ -38,7 +38,7 @@
 		},
 		"permutations": [
 			{
-				"condition": "q.block_state('bcc.cook:relative_position') == 'right'",
+				"condition": "q.block_state('bcc.cook:relative_position') == 'left'",
 				"components": {
 					"minecraft:geometry": {
 						"identifier": "geometry.counter.oak_wood",
@@ -64,7 +64,7 @@
 				}
 			},
 			{
-				"condition": "q.block_state('bcc.cook:relative_position') == 'left'",
+				"condition": "q.block_state('bcc.cook:relative_position') == 'right'",
 				"components": {
 					"minecraft:geometry": {
 						"identifier": "geometry.counter.oak_wood",

--- a/behavior_pack/blocks/bcc.cook/counter.oak_wood.json
+++ b/behavior_pack/blocks/bcc.cook/counter.oak_wood.json
@@ -38,7 +38,7 @@
 		},
 		"permutations": [
 			{
-				"condition": "q.block_state('bcc.cook:relative_position') == 'left'",
+				"condition": "q.block_state('bcc.cook:relative_position') == 'right'",
 				"components": {
 					"minecraft:geometry": {
 						"identifier": "geometry.counter.oak_wood",
@@ -64,7 +64,7 @@
 				}
 			},
 			{
-				"condition": "q.block_state('bcc.cook:relative_position') == 'right'",
+				"condition": "q.block_state('bcc.cook:relative_position') == 'left'",
 				"components": {
 					"minecraft:geometry": {
 						"identifier": "geometry.counter.oak_wood",

--- a/behavior_pack/scripts/components/blocks/oakWoodCounter.js
+++ b/behavior_pack/scripts/components/blocks/oakWoodCounter.js
@@ -4,8 +4,8 @@ import { setBlockState } from "../../utils/general";
 const axisOffsetMap = {
     "north": new Vector(-1, 0, 0),
     "south": new Vector(1, 0, 0),
-    "east": new Vector(0, 0, 1),
-    "west": new Vector(0, 0, -1)
+    "east": new Vector(0, 0, -1),
+    "west": new Vector(0, 0, 1)
 };
 const RelativePositionStateName = "bcc.cook:relative_position";
 var FacingDirection;

--- a/behavior_pack/src/components/blocks/oakWoodCounter.ts
+++ b/behavior_pack/src/components/blocks/oakWoodCounter.ts
@@ -1,4 +1,4 @@
-import { Block, Dimension, world } from "@minecraft/server";
+import { Block, Dimension } from "@minecraft/server";
 import { BlockId } from "../../constants/blockId";
 import { Vector } from "../../utils/vector";
 import { ComponentManager } from "../componentManager";
@@ -8,8 +8,8 @@ import { BlockStateSuperset } from "@minecraft/vanilla-data";
 const axisOffsetMap = {
 	"north": new Vector(-1, 0, 0),
 	"south": new Vector(1, 0, 0),
-	"east": new Vector(0, 0, 1),
-	"west": new Vector(0, 0, -1)
+	"east": new Vector(0, 0, -1),
+	"west": new Vector(0, 0, 1)
 };
 const RelativePositionStateName = "bcc.cook:relative_position" as keyof BlockStateSuperset;
 


### PR DESCRIPTION
When placed, the oak wood counter now selects the correct model depending on its neighbors.

The issue appears to be in the geometry itself, for some reason the left and right sides seem to be mislabeled. Even so, it can be accounted for in the behavior. It is recommend that the geometry bone labels be fixed, but until then this seems to work just fine.